### PR TITLE
Move PHP 5.4 tests from `WP_VERSION` `latest` to `5.1`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,4 +70,4 @@ jobs:
       env: WP_VERSION=trunk
     - stage: test
       php: 5.4
-      env: WP_VERSION=latest
+      env: WP_VERSION=5.1


### PR DESCRIPTION
Related wp-cli/wp-cli#5127